### PR TITLE
[BUGFIX] Lancer le npm publish à la création de tag plutôt que la release

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -4,8 +4,9 @@
 name: Node.js Package
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - '*'
 
 jobs:
   publish-npm:


### PR DESCRIPTION
Voir https://stackoverflow.com/questions/61891328/trigger-github-action-only-on-new-tags