### PR TITLE
[FEAT] Exposer toutes les méthodes de `testing-library`. 

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -7,6 +7,8 @@ import {
 } from '@ember/test-helpers';
 import { within as withinTL } from '@testing-library/dom';
 
+export * from '@testing-library/dom';
+
 /**
  * Wrap the EmberJS container with DOM testing library.
  * https://testing-library.com/docs/queries/about


### PR DESCRIPTION
Actuellement, nous n'exposons pas les helpers de [`testing-library`](https://testing-library.com/docs/dom-testing-library/api-async/)qui permettent par exemple d'attendre qu'un élement ne soit plus apparent. 

Je propose de les fournir dans la library afin de pouvoir les utiliser facilement.
