### PR TITLE
[TECH] Spécifier les imports de testing-library (PIX-7411)

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -5,9 +5,9 @@ import {
   render as renderHbs,
   visit as visitUrl,
 } from '@ember/test-helpers';
-import { within as withinTL } from '@testing-library/dom';
+import { within as withinTL } from '@testing-library/dom/dist/@testing-library/dom.umd.js';
 
-export * from '@testing-library/dom';
+export * from '@testing-library/dom/dist/@testing-library/dom.umd.js';
 
 /**
  * Wrap the EmberJS container with DOM testing library.


### PR DESCRIPTION
## :unicorn: Problème
Suite à nos essais d'Embroider, nous avons constaté qu'il n'arrivait pas à charger testing-library.

## :robot: Proposition
Pour permettre le bon fonctionnement, nous spécifions quel fichier nous souhaitons [comme expliqué dans la documentation](https://testing-library.com/docs/dom-testing-library/install#main-exports)

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester
Installer la dépendance sur un front `git://github.com/1024pix/ember-testing-library#specify-imports`
Vérifier le bon fonctionnement des tests