### PR TITLE
[TECH] Rétrograde @testing-library/dom en version 8.13.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
-        "@testing-library/dom": "~8.20.0",
+        "@testing-library/dom": "^8.13.0",
         "broccoli-funnel": "^3.0.8",
         "ember-auto-import": "^2.6.0",
         "ember-cli-babel": "^8.0.0",
@@ -4971,17 +4971,17 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.20.1.tgz",
-      "integrity": "sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-8.13.0.tgz",
+      "integrity": "sha512-9VHgfIatKNXQNaZTtLnalIy0jNZzY35a4S3oi08YAt9Hv1VsfZ/DfA45lM8D/UhtHBGJ4/lGwp0PZkVndRkoOQ==",
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
+        "@types/aria-query": "^4.2.0",
+        "aria-query": "^5.0.0",
         "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
+        "lz-string": "^1.4.4",
         "pretty-format": "^27.0.2"
       },
       "engines": {
@@ -5053,9 +5053,9 @@
       }
     },
     "node_modules/@types/aria-query": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.1.tgz",
-      "integrity": "sha512-XTIieEY+gvJ39ChLcB4If5zHtPxt3Syj5rgZR+e1ctpmK8NjPf0zFqsz4JpLJT0xla9GFDKjy8Cpu331nrmE1Q=="
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
+      "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",

--- a/package.json
+++ b/package.json
@@ -37,18 +37,18 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "@testing-library/dom": "~8.20.0",
+    "@testing-library/dom": "8.13.0",
     "broccoli-funnel": "^3.0.8",
     "ember-auto-import": "^2.6.0",
     "ember-cli-babel": "^8.0.0",
     "ember-cli-htmlbars": "^6.0.1"
   },
   "devDependencies": {
+    "@babel/eslint-parser": "^7.11.0",
     "@ember/optional-features": "^2.0.0",
     "@ember/string": "^3.0.1",
     "@ember/test-helpers": "^3.0.0",
     "@embroider/test-setup": "^3.0.0",
-    "@babel/eslint-parser": "^7.11.0",
     "broccoli-asset-rev": "^3.0.0",
     "ember-cli": "~4.12.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/tests/integration/index_test.js
+++ b/tests/integration/index_test.js
@@ -11,7 +11,7 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { hbs } from 'ember-cli-htmlbars';
 
-module.only('Integration | testing-library', function (hooks) {
+module('Integration | testing-library', function (hooks) {
   setupRenderingTest(hooks);
 
   module('#render', function () {


### PR DESCRIPTION
## :unicorn: Problème
Les versions plus récentes de @testing-library/dom ne semblent pas compatible avec embroider.

## :robot: Proposition
On rétrograde @testing-library/dom en version 8.13.0 qui était celle utilisé la version 0.7.1 de @1024pix/ember-testing-library.

## :rainbow: Remarques
> _Des infos supplémentaires, trucs et astuces ?_

## :100: Pour tester

