### PR TITLE
[TECH] Suppression du support Node 16 et Node 18 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "webpack": "^5.65.0"
       },
       "engines": {
-        "node": "^16 || ^18 || ^20"
+        "node": "^20"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     }
   },
   "engines": {
-    "node": "^16 || ^18 || ^20"
+    "node": "^20"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :boom: BREAKING_CHANGES
Arrêt du support de Node.js 16 et Node.js 20. Support de Node.js 20 uniquement.

## :christmas_tree: Problème
On supporte des versions qu'on ne souhaite plus maintenir.

## :gift: Proposition
Supprimer le support des versions de Node qu'on ne souhaite plus (16 et 18). Ne maintenir que Node 20.

## :star2: Remarques
RAS

## :santa: Pour tester
Vérifier que la CI passe. Idéalement link sur les projets qui utilisent Pix UI pour vérifier.