### PR TITLE
[FEATURE] Ajout du role combobox a la liste des roles cherchés dans `clickByName`

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -60,7 +60,10 @@ export async function render(template) {
  */
 export function clickByName(name, options = {}) {
   const { getByRole } = getScreen();
-  const element = getByRole(/button|link|radio|checkbox/, { ...options, name });
+  const element = getByRole(/button|link|radio|checkbox|combobox/, {
+    ...options,
+    name,
+  });
   return click(element);
 }
 


### PR DESCRIPTION
## :unicorn: Problème
La version 8 de [ember-power-select](https://github.com/cibernox/ember-power-select) change le role du composant select, de `button` a `combobox`. Ce qui fait casser des tests qui utilisent le `clickByName`

## :robot: Proposition
Rajouter le role combobox dans la liste des roles cherchés a être cliquer.

## :rainbow: Remarques
Le clickByName est un peu traitre avec sa gestion des roles. On pourrait renommer en `clickByRoleName` et/ou rendre la liste configurable facilement.

## :100: Pour tester
<!-- Les instructions pour reproduire le problème, les profils de test, le parcours spécifique à utiliser, etc. -->
