### PR TITLE
[TECH] Ajoute le support node@v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
         "webpack": "^5.65.0"
       },
       "engines": {
-        "node": "^20.15.0"
+        "node": "^20 || ^22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     }
   },
   "engines": {
-    "node": "^20.15.0"
+    "node": "^20 || ^22"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
## :jack_o_lantern: Problème
Ember testing library ne supporte pas Node.js en version 22 qui deviens LTS en octobre.

## :bat: Proposition
Ajouter le support de Node 22 pour ne pas bloquer l'install dans les projets qui utilisent cette lib.

## :spider_web: Remarques
J'ai été assez permissif sur les versions, en espérant qu'on ait pas les mêmes regressions qu'on avait eu sur des versions mineures de Node il y a quelques années 😬.

## :ghost: Pour tester
Pour l'instant rien ne change.
