### PR TITLE
[TECH] Contournement du TransitionAborted dans le visit de ember-test-helpers

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -3,6 +3,7 @@ import {
   fillIn,
   getRootElement,
   render as renderHbs,
+  settled,
   visit as visitUrl,
 } from '@ember/test-helpers';
 import { within as withinTL } from '@testing-library/dom/dist/@testing-library/dom.umd.js';
@@ -36,7 +37,16 @@ export function within(element) {
  * @returns DOM testing library helpers for the given page URL.
  */
 export async function visit(url) {
-  await visitUrl(url);
+  try {
+    await visitUrl(url);
+  } catch (e) {
+    // Workaround for test helper issue: https://github.com/emberjs/ember-test-helpers/issues/332
+    if (e.message !== 'TransitionAborted') {
+      throw e;
+    }
+  }
+  await settled();
+
   return getScreen();
 }
 


### PR DESCRIPTION
## ❄️ Problème

Lors d'un `visit` dans le tests ember, on peut avoir dans certains cas une erreur qui est throw `TransitionAborted`. Ce problème est lié au `visit` de `@ember/test-helpers`, quand une transition est réalisée dans un `beforeModel` asynchrone.

**Bug ouvert :** https://github.com/emberjs/ember-test-helpers/issues/332

## 🛷 Proposition

Le contournement proposé est d'englober le `visit` par un `try..catch` afin de traiter cette erreur spécifiquement et ne pas la remonter.

## ☃️ Remarques

N/A

## 🧑‍🎄 Pour tester

Les tests doivent fonctionner ISO.
